### PR TITLE
Test iv key after obtaining it

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -184,6 +184,7 @@ function loadPlugins() {
   pluginDirs.forEach((dir) => {
     const filteredPlugins = fs.readdirSync(dir).filter((item) => !/(^|\/)\.[^\/\.]/g.test(item));
     filteredPlugins.forEach((file) => {
+      if (file.substr(-2) !== 'js') return;
       const plug = require(path.join(dir, file));
 
       // Check plugin for correct shape

--- a/app/plugins/full-logger.js
+++ b/app/plugins/full-logger.js
@@ -1,8 +1,8 @@
+const decrypt = require('./lib/decrypt');
+
 const { app } = require('electron');
 const fs = require('fs');
 const path = require('path');
-const aesjs = require('aes-js');
-const msgpack5 = require('msgpack5');
 
 // Plugin Metadata
 const pluginName = 'Full Logger';
@@ -43,18 +43,6 @@ ${JSON.stringify(req)}
 ${JSON.stringify(res)}
 =============================================`);
   logfile.end();
-};
-
-// decrypt attempts to decrypt the traffic with the obtained
-const decrypt = (data) => {
-  const aesBody = data.subarray(0, data.length - 32);
-  const aesKey = data.subarray(data.length - 32, data.length);
-  const ivKey = Buffer.from(global.config.Config.Configuration.ivKey, 'utf8');
-
-  const rawBody = new aesjs.ModeOfOperation.cbc(aesKey, ivKey).decrypt(aesBody);
-  const body = rawBody.subarray(0, rawBody.length - rawBody[rawBody.length - 1]);
-  const msgpack = msgpack5().decode(body);
-  return msgpack;
 };
 
 // logDecrypted attempst to decrypt and print/dump the results

--- a/app/plugins/lib/decrypt.js
+++ b/app/plugins/lib/decrypt.js
@@ -1,0 +1,18 @@
+const aesjs = require('aes-js');
+const msgpack5 = require('msgpack5');
+
+// decrypt attempts to decrypt the traffic with the obtained
+const decrypt = (data) => {
+  if (!global.config.Config.Configuration.ivKey) return;
+
+  const aesBody = data.subarray(0, data.length - 32);
+  const aesKey = data.subarray(data.length - 32, data.length);
+  const ivKey = Buffer.from(global.config.Config.Configuration.ivKey, 'utf8');
+
+  const rawBody = new aesjs.ModeOfOperation.cbc(aesKey, ivKey).decrypt(aesBody);
+  const body = rawBody.subarray(0, rawBody.length - rawBody[rawBody.length - 1]);
+  const msgpack = msgpack5().decode(body);
+  return msgpack;
+};
+
+module.exports = decrypt;


### PR DESCRIPTION
This extracts `decrypt` from `full-logger` into a shared lib under plugins, since it will be used by practically all future plugins to read the payloads.

In `iv-extractor` we use this to try decrypt a request payload; if it's invalid, `msgpack5` will fail when attempting to convert it to json.