### PR TITLE
Fix invalid parameter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ github.event.inputs.version }}
-          generate_release_notes: true
           fail_on_unmatched_files: true
           files: |
             dist/*.exe


### PR DESCRIPTION
Remove `generate_release_notes` since it's always manually written anyways.