### PR TITLE
Retain target ranks of unowned units

### DIFF
--- a/app/plugins/armory-exporter.js
+++ b/app/plugins/armory-exporter.js
@@ -66,15 +66,16 @@ const transformUnitList = (units) => {
 
   // Find all target units the user does not own
   // These should be retained, with the unit data set to all minimum (rank 1, level 1, …)
-  Object.keys(targetData).filter(t => !result.find(u => u.u == t)).forEach(t => {
-    result.push({
-      u: t,
-      e: "000000",
-      r: 3,
-      p: 1,
-      q: 0,
-      t: targetData[t],
-    });
+  Object.keys(targetData).filter(t => !result.find(u => u.u == t))
+    .forEach(t => {
+      result.push({
+        u: t,
+        e: "000000",
+        r: 3,
+        p: 1,
+        q: 0,
+        t: targetData[t],
+      });
   });
   
   return result;

--- a/app/plugins/armory-exporter.js
+++ b/app/plugins/armory-exporter.js
@@ -64,6 +64,19 @@ const transformUnitList = (units) => {
     t: targetData[convertId(u.id)] || false,
   }));
 
+  // Find all target units the user does not own
+  // These should be retained, with the unit data set to all minimum (rank 1, level 1, …)
+  Object.keys(targetData).filter(t => !result.find(u => u.u == t)).forEach(t => {
+    result.push({
+      u: t,
+      e: "000000",
+      r: 3,
+      p: 1,
+      q: 0,
+      t: targetData[t],
+    });
+  });
+  
   return result;
 };
 

--- a/app/plugins/armory-exporter.js
+++ b/app/plugins/armory-exporter.js
@@ -66,7 +66,8 @@ const transformUnitList = (units) => {
 
   // Find all target units the user does not own
   // These should be retained, with the unit data set to all minimum (rank 1, level 1, …)
-  Object.keys(targetData).filter(t => !result.find(u => u.u == t))
+  Object.keys(targetData)
+    .filter(t => !result.find(u => u.u == t))
     .forEach(t => {
       result.push({
         u: t,

--- a/app/plugins/armory-exporter.js
+++ b/app/plugins/armory-exporter.js
@@ -67,18 +67,18 @@ const transformUnitList = (units) => {
   // Find all target units the user does not own
   // These should be retained, with the unit data set to all minimum (rank 1, level 1, …)
   Object.keys(targetData)
-    .filter(t => !result.find(u => u.u == t))
-    .forEach(t => {
+    .filter((t) => !result.find((u) => u.u == t))
+    .forEach((t) => {
       result.push({
         u: t,
-        e: "000000",
+        e: '000000',
         r: 3,
         p: 1,
         q: 0,
         t: targetData[t],
       });
-  });
-  
+    });
+
   return result;
 };
 


### PR DESCRIPTION
This PR updates armory exporter to retain target unit rank from the import armorytext if the unit is unowned.  
It will put a level 1 rank 1-0 unit, and put the same target rank.

Closes https://github.com/FabulousCupcake/pcr-exporter/pull/26.